### PR TITLE
Added Nginx configuration for reverse proxy

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name https://fastapi-book-project-upp9.onrender.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:10000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Description  
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details.  
- Configured Nginx reverse proxy for FastAPI.  

## Updated Note  

-NB: This is an update to my prior PR because it was unprofesssional

## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/999`) to confirm 404 response.  

## Notes  
- Invited `hng12-devbotops` as a collaborator.  
- Deployment URL: `https://fastapi-book-project-upp9.onrender.com`